### PR TITLE
Align `metaschema-xslt` with `metaschema` core

### DIFF
--- a/src/converter-gen/mvn-converters-xpl.sh
+++ b/src/converter-gen/mvn-converters-xpl.sh
@@ -11,7 +11,7 @@ Usage: ${BASE_COMMAND:-$(basename "${BASH_SOURCE[0]}")} METASCHEMA_XML OUTPUT_DI
 Produces XML-to-JSON and JSON-to-XML conversion transformations (XSLTs) from Metaschema XML source, using XML Calabash invoked from Maven.
 Please install Maven first.
 
-Additional arguments for XML Calabash should be specified in the `key=value` format.
+Additional arguments for XML Calabash should be specified in the "key=value" format.
 EOF
 }
 
@@ -31,9 +31,9 @@ ADDITIONAL_ARGS=$(shift 3; echo "${*// /\\ }")
 
 PIPELINE="${SCRIPT_DIR}/METASCHEMA-ALL-CONVERTERS.xpl"
 
-XMLTOJSON_CONVERTER_FILE="${OUTPUT_DIR}/${SCHEMA_NAME}-xml-to-json.xsl"
+XMLTOJSON_CONVERTER_FILE="${OUTPUT_DIR}/${SCHEMA_NAME}_xml-to-json-converter.xsl"
 
-JSONTOXML_CONVERTER_FILE="${OUTPUT_DIR}/${SCHEMA_NAME}-json-to-xml.xsl"
+JSONTOXML_CONVERTER_FILE="${OUTPUT_DIR}/${SCHEMA_NAME}_json-to-xml-converter.xsl"
 
 CALABASH_ARGS="-iMETASCHEMA=\"$METASCHEMA_XML\" \
                -oINT_0_echo-input=/dev/null \


### PR DESCRIPTION
# Committer Notes

Several key commits, namely 13cde791af0dc8682f7dd1532e36205ce968e20d (https://github.com/usnistgov/metaschema/pull/384) and a36f579e1e30abb2263895242cdbd2cf4bd29513 (https://github.com/usnistgov/metaschema/pull/380), were made after the `metaschema-xslt` migration. This PR aligns the new repository with these changes.

Also, this PR changes the filenames generated by the converter scripts to align with the ones previously used in the OSCAL repo.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- ~Do all automated CI/CD checks pass?~

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~
