### PR TITLE
Prevent error in output when using JSON parameter

### DIFF
--- a/src/converter-gen/json-to-xml/package-json-converter.xsl
+++ b/src/converter-gen/json-to-xml/package-json-converter.xsl
@@ -103,7 +103,7 @@
   
 <!--  -->
     <XSLT:template name="from-json">
-      <XSLT:if test="not(unparsed-text-available($file))" expand-text="true">
+      <XSLT:if test="matches($file, '\S') and not(unparsed-text-available($file))" expand-text="true">
         <nm:ERROR>No file found at { $file }</nm:ERROR>
       </XSLT:if>
       <XSLT:variable name="source">

--- a/src/converter-gen/mvn-jsonxml-converter-xsl.sh
+++ b/src/converter-gen/mvn-jsonxml-converter-xsl.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Fail early if an error occurs
-set -Eeuo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+# shellcheck source=../common/subcommand_common.bash
+source "$SCRIPT_DIR/../common/subcommand_common.bash"
 
 usage() {
     cat <<EOF
@@ -25,12 +26,7 @@ METASCHEMA_SOURCE=$1
 [[ -z "${2-}" ]] && { echo "Error: XSL_RESULT not specified"; usage; exit 1; }
 XSL_RESULT=$2
 
-ADDITIONAL_ARGS=$(shift 2; echo ${*// /\\ })
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-POM_FILE="${SCRIPT_DIR}/../../support/pom.xml"
-
-MAIN_CLASS="net.sf.saxon.Transform" # Saxon defined in pom.xml
+ADDITIONAL_ARGS=$(shift 2; echo "${*// /\\ }")
 
 if [ -e "$XSL_RESULT" ]
 then 
@@ -38,11 +34,7 @@ then
     rm -f ./$XSL_RESULT
 fi
 
-mvn \
-    -f "$POM_FILE" \
-    exec:java \
-    -Dexec.mainClass="$MAIN_CLASS" \
-    -Dexec.args="-xsl:${SCRIPT_DIR}/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl -s:\"$METASCHEMA_SOURCE\" -o:\"$XSL_RESULT\" $ADDITIONAL_ARGS"
+invoke_saxon "-xsl:${SCRIPT_DIR}/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl -s:\"$METASCHEMA_SOURCE\" -o:\"$XSL_RESULT\" $ADDITIONAL_ARGS"
 
 if [ -e "$XSL_RESULT" ]
 then 

--- a/src/converter-gen/mvn-xmljson-converter-xsl.sh
+++ b/src/converter-gen/mvn-xmljson-converter-xsl.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# Fail early if an error occurs
-set -Eeuo pipefail
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+# shellcheck source=../common/subcommand_common.bash
+source "$SCRIPT_DIR/../common/subcommand_common.bash"
 
 usage() {
     cat <<EOF
@@ -25,12 +26,7 @@ METASCHEMA_SOURCE=$1
 [[ -z "${2-}" ]] && { echo "Error: XSL_RESULT not specified"; usage; exit 1; }
 XSL_RESULT=$2
 
-ADDITIONAL_ARGS=$(shift 2; echo ${*// /\\ })
-
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
-POM_FILE="${SCRIPT_DIR}/../../support/pom.xml"
-
-MAIN_CLASS="net.sf.saxon.Transform" # Saxon defined in pom.xml
+ADDITIONAL_ARGS=$(shift 2; echo "${*// /\\ }")
 
 if [ -e "$XSL_RESULT" ]
 then 
@@ -38,11 +34,7 @@ then
     rm -f ./$XSL_RESULT
 fi
 
-mvn \
-    -f "$POM_FILE" \
-    exec:java \
-    -Dexec.mainClass="$MAIN_CLASS" \
-    -Dexec.args="-xsl:${SCRIPT_DIR}/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl -s:\"$METASCHEMA_SOURCE\" -o:\"$XSL_RESULT\" $ADDITIONAL_ARGS"
+invoke_saxon "-xsl:${SCRIPT_DIR}/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl -s:\"$METASCHEMA_SOURCE\" -o:\"$XSL_RESULT\" $ADDITIONAL_ARGS"
 
 if [ -e "$XSL_RESULT" ]
 then 

--- a/src/converter-gen/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
+++ b/src/converter-gen/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
@@ -127,11 +127,11 @@
       <xsl:text>&#xA;</xsl:text>
       <xsl:comment> JSON to XML conversion: Markdown to markup inferencing </xsl:comment>
       
-      <xsl:apply-templates mode="package-converter" select="document('markdown-to-supermodel-xml-converter.xsl')/xsl:*/( xsl:* except (xsl:output | xsl:mode) )"/>
+      <xsl:apply-templates mode="package-converter" select="document('json-to-xml/markdown-to-supermodel-xml-converter.xsl')/xsl:*/( xsl:* except (xsl:output | xsl:mode) )"/>
       
       <xsl:text>&#xA;</xsl:text>
       <xsl:comment> JSON to XML conversion: Supermodel serialization as XML </xsl:comment>
-      <xsl:apply-templates mode="package-converter" select="document('supermodel-to-xml.xsl')/xsl:*/( xsl:* except xsl:output )"/>
+      <xsl:apply-templates mode="package-converter" select="document('json-to-xml/supermodel-to-xml.xsl')/xsl:*/( xsl:* except xsl:output )"/>
     </xsl:copy>
   </xsl:template>
  
@@ -178,7 +178,7 @@
   
 <!--  -->
     <XSLT:template name="from-json">
-      <XSLT:if test="not(unparsed-text-available($file))" expand-text="true">
+      <XSLT:if test="matches($file, '\S') and not(unparsed-text-available($file))" expand-text="true">
         <nm:ERROR>No file found at { $file }</nm:ERROR>
       </XSLT:if>
       <XSLT:variable name="source">

--- a/src/converter-gen/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
+++ b/src/converter-gen/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
@@ -81,7 +81,7 @@
   
   <xsl:variable name="metaschema-source" select="/"/>
   
-  <xsl:variable name="json-serializer-xslt" select="document('supermodel-to-json.xsl')"/>
+  <xsl:variable name="json-serializer-xslt" select="document('xml-to-json/supermodel-to-json.xsl')"/>
   
   <xsl:template match="/">
     <xsl:variable name="converter">


### PR DESCRIPTION
# Committer Notes

This is a recreation of @kylelaker's PR (https://github.com/usnistgov/metaschema/pull/394) with some additional changes, namely correcting the XSL wrapper paths.

Previous text:
> Previously, if file was not specified (and json was), an error would
> be emitted about the file not being found. This was erroneous as only
> the JSON input should have been considered. This applies a small fix to
> remediate that, given by Wendell in https://github.com/usnistgov/OSCAL/issues/1849.
> 
> I am unsure whether this is the desired long-term fix but I figured
> opening a PR to memorialize the patch may be useful.
> 
> Co-authored-by: Wendell Piez [wendell.piez@nist.gov](mailto:wendell.piez@nist.gov)

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
