### PR TITLE
Modified the anchor url for internal links Fixed Issue#8

### DIFF
--- a/src/document/json/object-map-html.xsl
+++ b/src/document/json/object-map-html.xsl
@@ -217,7 +217,8 @@ details:not([open]) .show-closed { display: inline }
       <xsl:if test="empty(@_tree-json-id)">
          <xsl:message expand-text="true">not seeing json tree id for { name(.) }</xsl:message>
       </xsl:if>
-      <a class="OM-name" href="{ $reference-link }#{  @_tree-json-id }">
+      <xsl:variable as="xs:string" name="url-stem" select="replace($reference-link, '.html', '/')" />
+      <a class="OM-name" href="{ $url-stem }#{  @_tree-json-id }">
          <xsl:value-of select="(@key,@gi,@name)[1]"/>
       </a>
    </xsl:template>

--- a/src/document/xml/element-map-html.xsl
+++ b/src/document/xml/element-map-html.xsl
@@ -82,7 +82,8 @@ div.OM-map p { margin: 0ex }
    
    
    <xsl:template match="*[exists(@_tree-xml-id)]" mode="linked-name">
-      <a class="OM-name" href="{ $reference-link }#{ @_tree-xml-id }">
+      <xsl:variable as="xs:string" name="url-stem" select="replace($reference-link, '.html', '/')" />
+      <a class="OM-name" href="{ $url-stem }#{ @_tree-xml-id }">
          <xsl:value-of select="(@gi,@name)[1]"/>
       </a>
    </xsl:template> 


### PR DESCRIPTION
# XSLT-ed '.html' out of the link an replaced with '/' for XML and JSON outlines

PR fixes the Outline-page links to the Model-page internal links. The weirdness with the delayed load still remains in the destination Model-page, especially with all models and trying to link to models down on the page.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~
