### PR TITLE
Fixed #15 by pointing to /mode/... instead of  /reference/... To poin…

### DIFF
--- a/src/document/common/common-definitions.xsl
+++ b/src/document/common/common-definitions.xsl
@@ -11,7 +11,7 @@
     <xsl:key name="field-definition-by-name" match="/METASCHEMA/define-field"       use="@_key-name"/>
     <xsl:key name="flag-definition-by-name" match="/METASCHEMA/define-flag"         use="@_key-name"/>
     
-    <xsl:variable name="datatype-page" as="xs:string">/reference/datatypes</xsl:variable>
+    <xsl:variable name="datatype-page" as="xs:string">/models/datatypes</xsl:variable>
     
     <xsl:variable name="indenting" as="element()"
         xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">

--- a/src/document/json/json-docs-hugo-uswds.xsl
+++ b/src/document/json/json-docs-hugo-uswds.xsl
@@ -19,7 +19,7 @@
 
    <xsl:variable name="metaschema-code" select="/*/short-name || '-json'"/>
 
-   <xsl:variable name="datatype-page" as="xs:string"> /reference/datatypes</xsl:variable>
+   <xsl:variable name="datatype-page" as="xs:string"> /models/datatypes</xsl:variable>
 
    <xsl:strip-space elements="*"/>
 

--- a/src/document/json/object-map-html.xsl
+++ b/src/document/json/object-map-html.xsl
@@ -18,7 +18,7 @@
    </xsl:variable>
    <xsl:variable name="reference-link" select="$path-to-common || $reference-page"/>
    
-   <xsl:variable name="datatype-page">/reference/datatypes</xsl:variable>
+   <xsl:variable name="datatype-page">/models/datatypes</xsl:variable>
    
    <xsl:template match="/" mode="make-page">
       <html lang="en">

--- a/src/document/json/object-reference-html.xsl
+++ b/src/document/json/object-reference-html.xsl
@@ -12,7 +12,7 @@
    <xsl:param name="json-map-page"> json/outline</xsl:param>
    <xsl:param name="json-definitions-page">json/definitions</xsl:param>
 
-   <xsl:variable name="datatype-page" as="xs:string">/reference/datatypes</xsl:variable>
+   <xsl:variable name="datatype-page" as="xs:string">/models/datatypes</xsl:variable>
 
    <xsl:template match="metadata/namespace"/>
 

--- a/src/document/xml/element-map-html.xsl
+++ b/src/document/xml/element-map-html.xsl
@@ -18,7 +18,7 @@
    <xsl:variable name="reference-link" select="$path-to-common || $reference-page"/>
    
    
-   <xsl:variable name="datatype-page">/reference/datatypes</xsl:variable>
+   <xsl:variable name="datatype-page">/models/datatypes</xsl:variable>
    
 <!--http://localhost:1313/OSCAL/documentation/schema/catalog-layer/catalog/xml-model-map/
 http://localhost:1313/OSCAL/documentation/schema/catalog-layer/catalog/xml-schema/-->

--- a/src/document/xml/element-reference-html.xsl
+++ b/src/document/xml/element-reference-html.xsl
@@ -16,7 +16,7 @@
    <xsl:param name="xml-map-page"> xml/outline</xsl:param>
    <xsl:param name="xml-definitions-page">xml/definitions</xsl:param>
 
-   <xsl:variable name="datatype-page" as="xs:string">/reference/datatypes</xsl:variable>
+   <xsl:variable name="datatype-page" as="xs:string">/models/datatypes</xsl:variable>
 
    <xsl:template match="metadata/json-base-uri"/>
 

--- a/src/document/xml/xml-docs-hugo-uswds.xsl
+++ b/src/document/xml/xml-docs-hugo-uswds.xsl
@@ -32,7 +32,7 @@
 
    <xsl:variable name="metaschema-code" select="/*/short-name || '-xml'"/>
 
-   <xsl:variable name="datatype-page" as="xs:string"> /reference/datatypes</xsl:variable>
+   <xsl:variable name="datatype-page" as="xs:string"> /models/datatypes</xsl:variable>
 
    <xsl:strip-space elements="*"/>
 


### PR DESCRIPTION
# Committer Notes

<!-- Please provide a brief description of what this PR accomplishes. Be sure to reference any issues addressed. If the PR is a work-in-progress submitted for early review, please include [WIP] at the beginning of the title or mark the PR as DRAFT. -->

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.


### This fix should point to the local OSCAL-Reference types (nist-pages or local-local), not global metaschema, for metaschema. To point HREF to a new root, a new XSL variable would need to be added. I'd like to suggest also refactoring for the "href" composition template and relocate it to the unified callable place to have one file entry, instead of 7