### PR TITLE
Fix path from sample metaschema file to Schematron schema

### DIFF
--- a/src/compose/testing/working_metaschema.xml
+++ b/src/compose/testing/working_metaschema.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="../../validate/metaschema-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../../validate/metaschema-composition-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../../validate/metaschema-simple-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <!-- OSCAL CATALOG METASCHEMA -->
 <!-- validate with XSD and Schematron (linked) -->
 <METASCHEMA xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">


### PR DESCRIPTION
# Committer Notes

Fixes a broken reference to a Schematron file, by pointing to two Schematron files in the same folder as the broken reference. If that's not the correct fix, I can try again if you let me know which Schematron file(s) the file should reference.

**Interactive Testing Done**: When I validate this XML file in Oxygen, I see some warnings coming from `metaschema-composition-check.sch`, and if I disrupt the short name so it doesn't start with `oscal-`, I see a warning coming from `metaschema-simple-check.sch`. I no longer see an error about a Schematron schema not being found.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

Not applicable because this is not a change in a core feature.

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
