### PR TITLE
Remove trailing slash in `-page` options for modeldoc pipeline fixing relative path traversals

### DIFF
--- a/src/document/write-hugo-metaschema-docs.xpl
+++ b/src/document/write-hugo-metaschema-docs.xpl
@@ -37,15 +37,15 @@
       The base path that will be prepended to all relative links (e.g. '' or 'model-name/').
     </p:documentation>
   </p:option>
-  
-  <p:option name="json-outline-page" select="concat($page-base-path, replace($json-outline-filename, '.html', '/'))" />
-  <p:option name="json-reference-page" select="concat($page-base-path, replace($json-reference-filename, '.html', '/'))" />
-  <p:option name="json-index-page" select="concat($page-base-path, replace($json-index-filename, '.html', '/'))" />
-  <p:option name="json-definitions-page" select="concat($page-base-path, replace($json-definitions-filename, '.html', '/'))" />
-  <p:option name="xml-outline-page" select="concat($page-base-path, replace($xml-outline-filename, '.html', '/'))" />
-  <p:option name="xml-reference-page" select="concat($page-base-path, replace($xml-reference-filename, '.html', '/'))" />
-  <p:option name="xml-index-page" select="concat($page-base-path, replace($xml-index-filename, '.html', '/'))" />
-  <p:option name="xml-definitions-page" select="concat($page-base-path, replace($xml-definitions-filename, '.html', '/'))" />
+
+  <p:option name="json-outline-page" select="concat($page-base-path, replace($json-outline-filename, '.html', ''))" />
+  <p:option name="json-reference-page" select="concat($page-base-path, replace($json-reference-filename, '.html', ''))" />
+  <p:option name="json-index-page" select="concat($page-base-path, replace($json-index-filename, '.html', ''))" />
+  <p:option name="json-definitions-page" select="concat($page-base-path, replace($json-definitions-filename, '.html', ''))" />
+  <p:option name="xml-outline-page" select="concat($page-base-path, replace($xml-outline-filename, '.html', ''))" />
+  <p:option name="xml-reference-page" select="concat($page-base-path, replace($xml-reference-filename, '.html', ''))" />
+  <p:option name="xml-index-page" select="concat($page-base-path, replace($xml-index-filename, '.html', ''))" />
+  <p:option name="xml-definitions-page" select="concat($page-base-path, replace($xml-definitions-filename, '.html', ''))" />
 
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Import (subpipeline) -->


### PR DESCRIPTION
# Committer Notes

The model documentation pipeline uses the `-page` options to determine the relative path traversal from one documentation page to the next. Pages traverse up the tree by counting the number of slashes. The inclusion of a stray slash causes the relative links in the generated HTML to go up too many levels, which is handled inconsistently by web servers (some handle it fine, some throw errors, etc.)

This PR removes the slash at the end of page links, causing there to be one less upward traversal.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
