### PR TITLE
Remove unused templates in converter generators

### DIFF
--- a/src/converter-gen/json-to-xml/produce-json-converter.xsl
+++ b/src/converter-gen/json-to-xml/produce-json-converter.xsl
@@ -58,10 +58,7 @@
             </XSLT:if>
         </xsl:for-each>
     </xsl:template>
-    
-    <!-- Overriding the imported template for casting prose elements (wrt namespace) since we do not need it -->
-    <xsl:template name="cast-prose-template"/>
-    
+        
     <!-- Overriding interface template -->
     <xsl:template match="*" mode="make-match" as="xs:string">
         <xsl:variable name="matching-xml">
@@ -76,15 +73,7 @@
         <!--<xsl:sequence select="m:jsonize-path($matching-xml)"/>-->
         
     </xsl:template>
-    
-    <!-- Overriding interface template -->
-    <xsl:template match="*" mode="make-step" as="xs:string">
-        <xsl:variable name="step-xml">
-            <xsl:apply-templates select="." mode="make-xml-step"/>
-        </xsl:variable>
-        <xsl:sequence select="m:jsonize-path($step-xml)"/>
-    </xsl:template>
-    
+        
     <!-- Overriding interface template in mode 'make-pull' -->
     <xsl:template match="*" mode="make-pull">
         <xsl:apply-templates select="." mode="make-json-pull"/>

--- a/src/converter-gen/json-to-xml/produce-json-converter.xsl
+++ b/src/converter-gen/json-to-xml/produce-json-converter.xsl
@@ -22,6 +22,8 @@
     
     <xsl:output indent="yes"/>
     
+    <xsl:mode name="make-step" on-no-match="fail"><!-- Obsolete mode --></xsl:mode>
+
     <xsl:namespace-alias stylesheet-prefix="XSLT" result-prefix="xsl"/>
     
     <!-- $px is the prefix to be used on names in the XPath JSON -->

--- a/src/converter-gen/xml-to-json/produce-xml-converter.xsl
+++ b/src/converter-gen/xml-to-json/produce-xml-converter.xsl
@@ -27,11 +27,6 @@
     </xsl:template>
     
     <!-- Interface template for override -->
-    <xsl:template match="*" mode="make-step" as="xs:string">
-        <xsl:apply-templates select="." mode="make-xml-step"/>
-    </xsl:template>
-    
-    <!-- Interface template for override -->
     <xsl:template match="*" mode="make-pull">
         <xsl:apply-templates select="." mode="make-xml-pull"/>
     </xsl:template>

--- a/src/converter-gen/xml-to-json/produce-xml-converter.xsl
+++ b/src/converter-gen/xml-to-json/produce-xml-converter.xsl
@@ -16,6 +16,8 @@
     
     <xsl:namespace-alias stylesheet-prefix="XSLT" result-prefix="xsl"/>
     
+    <xsl:mode name="make-step" on-no-match="fail"><!-- Obsolete mode --></xsl:mode>
+
     <xsl:variable name="source-namespace" select="string(/*/@namespace)"/>
     <xsl:variable name="source-prefix"    select="string(/*/@prefix)"/>
     


### PR DESCRIPTION
# Committer Notes

There doesn't seem to be any code anywhere in this repo or the original metaschema repo that applies templates with mode="make-step" or calls a template named "cast-prose-template". If these templates are holdovers from an earlier development phase, they can be deleted.

On the other hand, if they are part of a planned new development and will be in use eventually, then deletion is not the right action (in which case, close this PR without merging). @wendellpiez , do you know the status of these templates?

This PR is not urgent. I'm working on testing the converter generators, but I'll skip over these templates for now.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
