### PR TITLE
Align schema `ref` and `id` fields

### DIFF
--- a/src/schema-gen/JSON-schema/make-json-schema-metamap.xsl
+++ b/src/schema-gen/JSON-schema/make-json-schema-metamap.xsl
@@ -57,7 +57,7 @@
                 <map key="json-schema-directive">
                     <string key="title">Schema Directive</string>
                     <string key="description">A JSON Schema directive to bind a specific schema to its document instance.</string>
-                    <string key="$id">#json-schema-directive</string>
+                    <string key="$id">#/definitions/json-schema-directive</string>
                     <string key="$ref">#/definitions/URIReferenceDatatype</string>
                 </map>
                 <xsl:apply-templates select="define-assembly | define-field"/>
@@ -94,7 +94,7 @@
     <xsl:template match="define-assembly" mode="root-requirement">
         <map key="properties">
             <map key="$schema">
-                <string key="$ref">#json-schema-directive</string>
+                <string key="$ref">#/definitions/json-schema-directive</string>
             </map>
             <map key="{root-name}">
                 <xsl:apply-templates select="." mode="make-ref"/>
@@ -123,7 +123,7 @@
             </string>
         </xsl:if>
     </xsl:template>
-    
+
     <xsl:template match="*" mode="make-ref">
         <string key="$ref">
             <xsl:apply-templates mode="make-definition-id" select="."/>
@@ -131,7 +131,7 @@
     </xsl:template>
     
     <xsl:template match="*" mode="make-definition-id">
-        <xsl:text expand-text="true">#{ substring(replace(@_metaschema-json-id,'/','_'),2) }</xsl:text>
+        <xsl:text expand-text="true">#/definitions/{ $composed-metaschema/*/short-name }-{@_key-name}</xsl:text>
     </xsl:template>
 
     <xsl:template priority="100" match="METASCHEMA/define-assembly">


### PR DESCRIPTION
# Committer Notes

This PR fixes some issues community members have had parsing JSON schemas (https://github.com/usnistgov/metaschema-xslt/issues/74, https://github.com/usnistgov/OSCAL/issues/1908) by aligning the generated `$id` and `$ref` properties.

This change will change `$id` fields on generated schemas, which may constitute breaking changes for downstream code generators.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema-xslt/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema-xslt/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all [website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
